### PR TITLE
New content type for "application/x-www-form-urlencoded"

### DIFF
--- a/Everest.UnitTests/Everest.UnitTests.csproj
+++ b/Everest.UnitTests/Everest.UnitTests.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="WwwFormUrlEncodedContentTests.cs" />
     <Compile Include="ConnectionLimitTest.cs" />
     <Compile Include="Fakes\AlwaysThrowsOnSendingAdapter.cs" />
     <Compile Include="DisposeTest.cs" />

--- a/Everest.UnitTests/WwwFormUrlEncodedContentTests.cs
+++ b/Everest.UnitTests/WwwFormUrlEncodedContentTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Everest.Content;
+using NUnit.Framework;
+
+namespace Everest.UnitTests
+{
+    [TestFixture]
+    public class WwwFormUrlEncodedContentTests
+    {
+        [Test]
+        public void CanConstructContentFromDictionary()
+        {
+            var dictionary = new Dictionary<string, string>
+                {
+                    {"Value1", "Alpha"},
+                    {"Value2", "Bravo"},
+                    {"Value3", "Charlie"},
+                };
+
+            var content = new WwwFormUrlEncodedContent(dictionary);
+
+            Assert.That(content.MediaType, Is.EqualTo("application/x-www-form-urlencoded"));
+
+            using (var reader = new StreamReader(content.AsStream()))
+            {
+                var contentString = reader.ReadToEnd();
+                Assert.That(contentString, Is.EqualTo("Value1=Alpha&Value2=Bravo&Value3=Charlie"));
+            }
+        }
+
+        [Test]
+        public void CanConstructContentFromDictionaryWithCharactersNeedingEscaping()
+        {
+            var dictionary = new Dictionary<string, string>
+                {
+                    {"Value1", "Al&pha"},
+                    {"Value2", "Bra<vo Beta"},
+                    {"Value3", "Char\"lie"},
+                };
+
+            var content = new WwwFormUrlEncodedContent(dictionary);
+
+            Assert.That(content.MediaType, Is.EqualTo("application/x-www-form-urlencoded"));
+
+            using (var reader = new StreamReader(content.AsStream()))
+            {
+                var contentString = reader.ReadToEnd();
+                Assert.That(contentString, Is.EqualTo("Value1=Al%26pha&Value2=Bra%3cvo+Beta&Value3=Char%22lie"));
+            }
+        }
+
+        [Test]
+        public void CanConstructContentFromObjectProperties()
+        {
+            var objectSource = new
+                {
+                    Value1="Alpha",
+                    Value2="Bravo",
+                    Value3="Charlie",
+                };
+
+            var content = new WwwFormUrlEncodedContent(objectSource);
+
+            Assert.That(content.MediaType, Is.EqualTo("application/x-www-form-urlencoded"));
+
+            using (var reader = new StreamReader(content.AsStream()))
+            {
+                var contentString = reader.ReadToEnd();
+                Assert.That(contentString, Is.EqualTo("Value1=Alpha&Value2=Bravo&Value3=Charlie"));
+            }
+        }
+    }
+}

--- a/Everest/Content/WwwFormUrlEncodedContent.cs
+++ b/Everest/Content/WwwFormUrlEncodedContent.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Everest.Content
+{
+    public class WwwFormUrlEncodedContent : StringBodyContent
+    {
+        public WwwFormUrlEncodedContent(object values, string mediaType = "application/x-www-form-urlencoded")
+            : base(BuildBody(values), mediaType)
+        {
+        }
+
+        public WwwFormUrlEncodedContent(Dictionary<string, string> values, string mediaType = "application/x-www-form-urlencoded")
+            : base(BuildBody(values), mediaType)
+        {
+        }
+
+        private static string BuildBody(object values)
+        {
+            var properties = values.GetType().GetProperties();
+
+            return BuildBody(properties
+                .Where(x => x.GetIndexParameters().Length == 0)
+                .ToDictionary(x => x.Name, x=>x.GetValue(values, null).ToString()));
+        }
+
+        private static string BuildBody(Dictionary<string, string> values)
+        {
+            return String.Join("&", values.Select(x => HttpUtility.UrlEncode(x.Key) + "=" + HttpUtility.UrlEncode(x.Value)));
+        }
+    }
+}

--- a/Everest/Everest.csproj
+++ b/Everest/Everest.csproj
@@ -38,10 +38,12 @@
     <Reference Include="System.Net.Http">
       <HintPath>..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Content\WwwFormUrlEncodedContent.cs" />
     <Compile Include="Content\StreamBodyContent.cs" />
     <Compile Include="Compression\AcceptEncoding.cs" />
     <Compile Include="Headers\RequestHeader.cs" />


### PR DESCRIPTION
Added a new Content object that will build a "application/x-www-form-urlencoded" media type for you from a dictionary or an object's properties.

Have added a reference to System.Web to use HttpUtility.UrlEncode
