### PR TITLE
Include Proxy as a Pipeline Option

### DIFF
--- a/Everest/Everest.csproj
+++ b/Everest/Everest.csproj
@@ -93,6 +93,8 @@
     <Compile Include="Status\StatusAcceptability.cs" />
     <Compile Include="Content\StringBodyContent.cs" />
     <Compile Include="Pipeline\UnsupportedOptionException.cs" />
+    <Compile Include="Proxy\WebProxy.cs" />
+    <Compile Include="Proxy\IWebProxy.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Nuget - usage.txt" />

--- a/Everest/Proxy/IWebProxy.cs
+++ b/Everest/Proxy/IWebProxy.cs
@@ -1,0 +1,20 @@
+using System;
+using Everest.Pipeline;
+using SysIWebProxy = System.Net.IWebProxy;
+
+namespace Everest.Proxy
+{
+    public abstract class IWebProxy
+    {
+        private readonly SysIWebProxy _proxy;
+        protected abstract SysIWebProxy CreateWebProxy(string host);
+
+        public IWebProxy (string host) {
+            _proxy = CreateWebProxy(host);
+        }
+
+        public SysIWebProxy Proxy {
+            get { return _proxy; }
+        }
+    }
+}

--- a/Everest/Proxy/WebProxy.cs
+++ b/Everest/Proxy/WebProxy.cs
@@ -1,0 +1,16 @@
+using System;
+using Everest.Pipeline;
+using SysIWebProxy = System.Net.IWebProxy;
+using SysWebProxy = System.Net.WebProxy;
+
+namespace Everest.Proxy
+{
+    public class WebProxy : IWebProxy, PipelineOption
+    {
+        public WebProxy(string host) : base (host) { }
+
+        protected override SysIWebProxy CreateWebProxy (string host) {
+            return new SysWebProxy(host) as SysIWebProxy;
+        }
+    }
+}

--- a/Everest/SystemNetHttp/AdapterOptions.cs
+++ b/Everest/SystemNetHttp/AdapterOptions.cs
@@ -2,6 +2,7 @@
 using Everest.Compression;
 using Everest.Redirection;
 using Everest.Timing;
+using Everest.Proxy;
 
 namespace Everest.SystemNetHttp
 {
@@ -11,5 +12,6 @@ namespace Everest.SystemNetHttp
         public CachePolicy CachePolicy;
         public AcceptEncoding AcceptEncoding;
         public RequestTimeout Timeout;
+        public WebProxy WebProxy;
     }
 }

--- a/Everest/SystemNetHttp/SystemNetHttpClientAdapter.cs
+++ b/Everest/SystemNetHttp/SystemNetHttpClientAdapter.cs
@@ -32,6 +32,11 @@ namespace Everest.SystemNetHttp
                 handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
             }
 
+            if (options.WebProxy != null)
+            {
+                handler.Proxy = options.WebProxy.Proxy;
+            }
+
             _client = new HttpClient(handler);
 
             if (options.Timeout != null)

--- a/Everest/SystemNetHttp/SystemNetHttpClientAdapterFactory.cs
+++ b/Everest/SystemNetHttp/SystemNetHttpClientAdapterFactory.cs
@@ -2,6 +2,7 @@
 using Everest.Caching;
 using Everest.Compression;
 using Everest.Pipeline;
+using Everest.Proxy;
 using Everest.Redirection;
 using Everest.Timing;
 
@@ -18,13 +19,15 @@ namespace Everest.SystemNetHttp
             {
                 AutoRedirect = AutoRedirect.AutoRedirectButDoNotForwardAuthorizationHeader,
                 CachePolicy = new CachePolicy {Cache = false},
-                AcceptEncoding = new AcceptEncoding {AcceptGzipAndDeflate = true}
+                AcceptEncoding = new AcceptEncoding {AcceptGzipAndDeflate = true},
+                WebProxy = null
             };
 
             options.Use<AutoRedirect>(option => { adapterOptions.AutoRedirect = option; });
             options.Use<CachePolicy>(option => { adapterOptions.CachePolicy = option; });
             options.Use<AcceptEncoding>(option => { adapterOptions.AcceptEncoding = option; });
             options.Use<RequestTimeout>(option => adapterOptions.Timeout = option );
+            options.Use<WebProxy>(option => adapterOptions.WebProxy = option );
 
             return CreateClient(adapterOptions);
         }


### PR DESCRIPTION
Main use case for this addition has been sending Everest requests into fiddler.

Allow the settings of the IWebProxy used by the request as an option.
Includes interface and WebProxy implementation.
